### PR TITLE
Improve SFT Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,27 +59,29 @@ We used the following datasets for fine-tuning.
 
 **NOTE**: The datasets mentioned above are not public as of now. We're in the process of making them accessible. Stay tuned for updates.
 
-### Fine-tuning
+### Full Parameter Supervised Fine-tuning
 
-#### For the 1.3B model
+#### For the 1.3B model on A100 40GB 1node_8gpu
 
 ```bash
-accelerate launch --config_file accelerate_config_zero3.yaml \
+accelerate launch --config_file accelerate_config_zero1.yaml \
     train.py \
     --num_train_epochs 2 \
-    --per_device_train_batch_size 1 \
-    --gradient_accumulation_steps 32 \
+    --per_device_train_batch_size 4 \
+    --gradient_accumulation_steps 16 \
     --learning_rate 1e-5 \
     --warmup_ratio 0.1 \
     --lr_scheduler cosine \
     --bf16 \
     --max_seq_length 2048 \
+    --gradient_checkpointing \
+    --logging_steps 1 \
     --data_files jamp.json janli.json jcommonsenseqa.json jemhopqa.json jnli.json jsem.json jsick.json jsquad.json jsts.json niilc.json dolly_deepl.json oasst_deepl.json \
     --model_name_or_path llm-jp/llm-jp-1.3b-v1.0 \
     --output_dir results/llm-jp-1.3b-v1.0_jaster-dolly-oasst
 ```
 
-#### For the 13B model
+#### For the 13B model on A100 40GB 1node_8gpu
 
 ```bash
 accelerate launch --config_file accelerate_config_zero3.yaml \
@@ -93,6 +95,30 @@ accelerate launch --config_file accelerate_config_zero3.yaml \
     --bf16 \
     --max_seq_length 2048 \
     --gradient_checkpointing \
+    --logging_steps 1 \
+    --data_files jamp.json janli.json jcommonsenseqa.json jemhopqa.json jnli.json jsem.json jsick.json jsquad.json jsts.json niilc.json dolly_deepl.json oasst_deepl.json \
+    --model_name_or_path llm-jp/llm-jp-13b-v1.0 \
+    --output_dir results/llm-jp-13b-v1.0_jaster-dolly-oasst
+```
+
+#### For the 13B model on A100 40GB 8node_64gpu
+
+```bash
+accelerate launch --config_file accelerate_config_zero2.8node.yaml \
+    --main_process_ip $main_process_ip \
+    --main_process_port 29500 \
+    --machine_rank $machine_rank \
+    train.py \
+    --num_train_epochs 2 \
+    --per_device_train_batch_size 3 \
+    --gradient_accumulation_steps 6 \
+    --learning_rate 1e-5 \
+    --warmup_ratio 0.1 \
+    --lr_scheduler cosine \
+    --bf16 \
+    --max_seq_length 2048 \
+    --gradient_checkpointing \
+    --logging_steps 1 \
     --data_files jamp.json janli.json jcommonsenseqa.json jemhopqa.json jnli.json jsem.json jsick.json jsquad.json jsts.json niilc.json dolly_deepl.json oasst_deepl.json \
     --model_name_or_path llm-jp/llm-jp-13b-v1.0 \
     --output_dir results/llm-jp-13b-v1.0_jaster-dolly-oasst

--- a/accelerate_config_zero1.yaml
+++ b/accelerate_config_zero1.yaml
@@ -14,8 +14,4 @@ tpu_use_cluster: false
 tpu_use_sudo: false
 use_cpu: false
 deepspeed_config:
-  zero_stage: 3
-  offload_optimizer_device: none
-  offload_param_device: cpu
-  zero3_init_flag: true
-  zero3_save_16bit_model: true
+  zero_stage: 1

--- a/accelerate_config_zero2.8node.yaml
+++ b/accelerate_config_zero2.8node.yaml
@@ -2,11 +2,10 @@ compute_environment: LOCAL_MACHINE
 debug: false
 distributed_type: DEEPSPEED
 downcast_bf16: 'no'
-machine_rank: 0
 main_training_function: main
 mixed_precision: bf16
-num_machines: 1
-num_processes: 8
+num_machines: 8
+num_processes: 64
 rdzv_backend: static
 same_network: true
 tpu_env: []
@@ -14,8 +13,5 @@ tpu_use_cluster: false
 tpu_use_sudo: false
 use_cpu: false
 deepspeed_config:
-  zero_stage: 3
-  offload_optimizer_device: none
-  offload_param_device: cpu
-  zero3_init_flag: true
-  zero3_save_16bit_model: true
+  deepspeed_multinode_launcher: standard
+  zero_stage: 2

--- a/accelerate_config_zero2.yaml
+++ b/accelerate_config_zero2.yaml
@@ -1,10 +1,5 @@
 compute_environment: LOCAL_MACHINE
 debug: false
-deepspeed_config:
-  offload_optimizer_device: none
-  offload_param_device: none
-  zero3_init_flag: false
-  zero_stage: 2
 distributed_type: DEEPSPEED
 downcast_bf16: 'no'
 machine_rank: 0
@@ -18,3 +13,5 @@ tpu_env: []
 tpu_use_cluster: false
 tpu_use_sudo: false
 use_cpu: false
+deepspeed_config:
+  zero_stage: 2

--- a/accelerate_config_zero3.8node.yaml
+++ b/accelerate_config_zero3.8node.yaml
@@ -2,11 +2,10 @@ compute_environment: LOCAL_MACHINE
 debug: false
 distributed_type: DEEPSPEED
 downcast_bf16: 'no'
-machine_rank: 0
 main_training_function: main
 mixed_precision: bf16
-num_machines: 1
-num_processes: 8
+num_machines: 8
+num_processes: 64
 rdzv_backend: static
 same_network: true
 tpu_env: []
@@ -14,8 +13,7 @@ tpu_use_cluster: false
 tpu_use_sudo: false
 use_cpu: false
 deepspeed_config:
+  deepspeed_multinode_launcher: standard
   zero_stage: 3
-  offload_optimizer_device: none
-  offload_param_device: cpu
   zero3_init_flag: true
   zero3_save_16bit_model: true


### PR DESCRIPTION
- Add settings for multinode training
  - 8node_16gpu - jaster full SFT
    - 13B: 1[hour/epoch]
    - 1.3B: 8[min/epoch]
- Improve settings in accelerate_config files
- Improve base model creation
- Improve tokenizer settings