### PR TITLE
Revise TrainingArguments.lr_scheduler as lr_scheduler_type and update dataset path

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ python train.py \
     --per_device_train_batch_size 1 \
     --learning_rate 1e-5 \
     --warmup_ratio 0.1 \
-    --lr_scheduler cosine \
+    --lr_scheduler_type cosine \
     --data_files data/example.jsonl \
     --model_name_or_path llm-jp/llm-jp-1.3b-v1.0 \
     --output_dir results/
@@ -70,7 +70,7 @@ accelerate launch --config_file configs/accelerate_config_zero1.yaml \
     --gradient_accumulation_steps 8 \
     --learning_rate 1e-5 \
     --warmup_ratio 0.1 \
-    --lr_scheduler cosine \
+    --lr_scheduler_type cosine \
     --bf16 \
     --max_seq_length 2048 \
     --logging_steps 1 \
@@ -89,7 +89,7 @@ accelerate launch --config_file configs/accelerate_config_zero3.yaml \
     --gradient_accumulation_steps 32 \
     --learning_rate 1e-5 \
     --warmup_ratio 0.1 \
-    --lr_scheduler cosine \
+    --lr_scheduler_type cosine \
     --bf16 \
     --max_seq_length 2048 \
     --gradient_checkpointing \
@@ -115,7 +115,7 @@ accelerate launch --config_file configs/accelerate_config_zero2.8node.yaml \
     --gradient_accumulation_steps 6 \
     --learning_rate 1e-5 \
     --warmup_ratio 0.1 \
-    --lr_scheduler cosine \
+    --lr_scheduler_type cosine \
     --bf16 \
     --max_seq_length 2048 \
     --logging_steps 1 \
@@ -135,7 +135,7 @@ CUDA_VISIBLE_DEVICES=0 python train.py \
     --gradient_accumulation_steps 4 \
     --learning_rate 1e-4 \
     --warmup_ratio 0.1 \
-    --lr_scheduler cosine \
+    --lr_scheduler_type cosine \
     --bf16 \
     --max_seq_length 2048 \
     --data_files jamp.json janli.json jcommonsenseqa.json jemhopqa.json jnli.json jsem.json jsick.json jsquad.json jsts.json niilc.json dolly_deepl.json oasst_deepl.json \
@@ -153,7 +153,7 @@ CUDA_VISIBLE_DEVICES=0 python train.py \
     --gradient_accumulation_steps 32 \
     --learning_rate 1e-4 \
     --warmup_ratio 0.1 \
-    --lr_scheduler cosine \
+    --lr_scheduler_type cosine \
     --bf16 \
     --max_seq_length 2048 \
     --gradient_checkpointing \
@@ -173,7 +173,7 @@ accelerate launch --config_file configs/accelerate_config_zero1.yaml \
     --gradient_accumulation_steps 8 \
     --learning_rate 1e-4 \
     --warmup_ratio 0.1 \
-    --lr_scheduler cosine \
+    --lr_scheduler_type cosine \
     --bf16 \
     --max_seq_length 2048 \
     --data_files jamp.json janli.json jcommonsenseqa.json jemhopqa.json jnli.json jsem.json jsick.json jsquad.json jsts.json niilc.json dolly_deepl.json oasst_deepl.json \
@@ -192,7 +192,7 @@ accelerate launch --config_file configs/accelerate_config_zero1.yaml \
     --gradient_accumulation_steps 16 \
     --learning_rate 1e-4 \
     --warmup_ratio 0.1 \
-    --lr_scheduler cosine \
+    --lr_scheduler_type cosine \
     --bf16 \
     --max_seq_length 2048 \
     --data_files jamp.json janli.json jcommonsenseqa.json jemhopqa.json jnli.json jsem.json jsick.json jsquad.json jsts.json niilc.json dolly_deepl.json oasst_deepl.json \

--- a/mdx/README.md
+++ b/mdx/README.md
@@ -5,8 +5,8 @@
 Create directories and symbolic links for the datasets and the models:
 
 ```bash
-$ mkdir datasets models results
-$ ln -s absolute_path_for_dataset_directory datasets/
+$ mkdir models results
+$ ln -s absolute_path_for_dataset_directory dataset
 $ ln -s absolute_path_for_model_directory models/
 ```
 
@@ -33,9 +33,9 @@ Examples are using `jaster` as dataset and `llm-jp-1.3b-v1.0` as base model.
   - gradient_accumulation_steps
 - examples:
   - 1.3B model on A100 40GB 1node_8gpu with `accelerate_config_zero1.yaml`
-    - `$ mdx/train_full_single_node.sh configs/accelerate_config_zero1.yaml llm-jp/llm-jp-1.3b-v1.0 llm-jp/llm-jp-1.3b-v1.0 datasets/v1.1.1 mdx/dataset_jaster.sh 2 results/llm-jp-1.3b-instruct-full-jaster-v1.0 8 8`
+    - `$ mdx/train_full_single_node.sh configs/accelerate_config_zero1.yaml llm-jp/llm-jp-1.3b-v1.0 llm-jp/llm-jp-1.3b-v1.0 ./dataset mdx/dataset_jaster.sh 2 results/llm-jp-1.3b-instruct-full-jaster-v1.0 8 8`
   - 13B model on A100 40GB 1node_8gpu with `accelerate_config_zero3.yaml`
-    - `$ mdx/train_full_single_node_gradient_checkpointing.sh configs/accelerate_config_zero3.yaml llm-jp/llm-jp-13b-v1.0 llm-jp/llm-jp-13b-v1.0 datasets/v1.1.1 mdx/dataset_jaster.sh 2 results/llm-jp-13b-instruct-full-jaster-v1.0 1 32`
+    - `$ mdx/train_full_single_node_gradient_checkpointing.sh configs/accelerate_config_zero3.yaml llm-jp/llm-jp-13b-v1.0 llm-jp/llm-jp-13b-v1.0 ./dataset mdx/dataset_jaster.sh 2 results/llm-jp-13b-instruct-full-jaster-v1.0 1 32`
 
 #### Multi-node Multi-GPU Training
 For multi-node training, you need to specify the IP address of the network used for inter-node communication of the rank 0 (master) node as `main_process_ip` arguments.
@@ -56,7 +56,7 @@ In addition, you need to run `mdx/train_full_multi_node.sh` from all the nodes w
   - machine_rank
 - example:
   - 13B model on A100 40GB 8node_64gpu with `accelerate_config_zero2.8node.yaml`
-    - `$ mdx/train_full_multi_node.sh configs/accelerate_config_zero2.8node.yaml llm-jp/llm-jp-13b-v1.0 llm-jp/llm-jp-13b-v1.0 datasets/v1.1.1 mdx/dataset_jaster.sh 2 results/llm-jp-13b-instruct-full-jaster-v1.0 3 6 10.???.???.??? [0-7]`
+    - `$ mdx/train_full_multi_node.sh configs/accelerate_config_zero2.8node.yaml llm-jp/llm-jp-13b-v1.0 llm-jp/llm-jp-13b-v1.0 ./dataset mdx/dataset_jaster.sh 2 results/llm-jp-13b-instruct-full-jaster-v1.0 3 6 10.???.???.??? [0-7]`
 
 ### Fine-tuning with PEFT
 
@@ -75,9 +75,9 @@ In addition, you need to run `mdx/train_full_multi_node.sh` from all the nodes w
   - gradient_accumulation_steps
 - examples:
   - 1.3B model on single A100 40GB
-    - `$ CUDA_VISIBLE_DEVICES=0 mdx/train_peft_single_gpu.sh llm-jp/llm-jp-1.3b-v1.0 llm-jp/llm-jp-1.3b-v1.0 datasets/v1.1.1 mdx/dataset_jaster.sh 5 results/llm-jp-1.3b-instruct-lora-jaster-v1.0 8 4`
+    - `$ CUDA_VISIBLE_DEVICES=0 mdx/train_peft_single_gpu.sh llm-jp/llm-jp-1.3b-v1.0 llm-jp/llm-jp-1.3b-v1.0 ./dataset mdx/dataset_jaster.sh 5 results/llm-jp-1.3b-instruct-lora-jaster-v1.0 8 4`
   - 13B model on single A100 40GB
-    - `$ CUDA_VISIBLE_DEVICES=0 mdx/train_peft_single_gpu_gradient_checkpointing.sh llm-jp/llm-jp-13b-v1.0 llm-jp/llm-jp-13b-v1.0 datasets/v1.1.1 mdx/dataset_jaster.sh 5 results/llm-jp-13b-instruct-lora-jaster-v1.0 1 32`
+    - `$ CUDA_VISIBLE_DEVICES=0 mdx/train_peft_single_gpu_gradient_checkpointing.sh llm-jp/llm-jp-13b-v1.0 llm-jp/llm-jp-13b-v1.0 ./dataset mdx/dataset_jaster.sh 5 results/llm-jp-13b-instruct-lora-jaster-v1.0 1 32`
 
 #### Single-node Multi-GPU Training
 - script:
@@ -93,6 +93,6 @@ In addition, you need to run `mdx/train_full_multi_node.sh` from all the nodes w
   - gradient_accumulation_steps
 - examples:
   - 1.3B model on A100 40GB 1node_8gpu with `accelerate_config_zero1.yaml`
-    - `$ mdx/train_peft_multi_gpu.sh llm-jp/llm-jp-1.3b-v1.0 llm-jp/llm-jp-1.3b-v1.0 datasets/v1.1.1 mdx/dataset_jaster.sh 5 results/llm-jp-1.3b-instruct-lora-jaster-v1.0 8 8`
+    - `$ mdx/train_peft_multi_gpu.sh llm-jp/llm-jp-1.3b-v1.0 llm-jp/llm-jp-1.3b-v1.0 ./dataset mdx/dataset_jaster.sh 5 results/llm-jp-1.3b-instruct-lora-jaster-v1.0 8 8`
   - 13B model on A100 40GB 1node_8gpu with `accelerate_config_zero1.yaml`
-    - `$ mdx/train_peft_multi_gpu.sh llm-jp/llm-jp-13b-v1.0 llm-jp/llm-jp-13b-v1.0 datasets/v1.1.1 mdx/dataset_jaster.sh 5 results/llm-jp-13b-instruct-lora-jaster-v1.0 1 16`
+    - `$ mdx/train_peft_multi_gpu.sh llm-jp/llm-jp-13b-v1.0 llm-jp/llm-jp-13b-v1.0 ./dataset mdx/dataset_jaster.sh 5 results/llm-jp-13b-instruct-lora-jaster-v1.0 1 16`

--- a/mdx/train_full_multi_node.sh
+++ b/mdx/train_full_multi_node.sh
@@ -28,7 +28,7 @@ accelerate launch --config_file $config_file \
     --gradient_accumulation_steps $gradient_accumulation_steps \
     --learning_rate 1e-5 \
     --warmup_ratio 0.1 \
-    --lr_scheduler cosine \
+    --lr_scheduler_type cosine \
     --bf16 \
     --max_seq_length 2048 \
     --logging_steps 1 \

--- a/mdx/train_full_single_node.sh
+++ b/mdx/train_full_single_node.sh
@@ -17,7 +17,7 @@ accelerate launch --config_file $config_file \
     --gradient_accumulation_steps $gradient_accumulation_steps \
     --learning_rate 1e-5 \
     --warmup_ratio 0.1 \
-    --lr_scheduler cosine \
+    --lr_scheduler_type cosine \
     --bf16 \
     --max_seq_length 2048 \
     --logging_steps 1 \

--- a/mdx/train_full_single_node_gradient_checkpointing.sh
+++ b/mdx/train_full_single_node_gradient_checkpointing.sh
@@ -17,7 +17,7 @@ accelerate launch --config_file $config_file \
     --gradient_accumulation_steps $gradient_accumulation_steps \
     --learning_rate 1e-5 \
     --warmup_ratio 0.1 \
-    --lr_scheduler cosine \
+    --lr_scheduler_type cosine \
     --bf16 \
     --max_seq_length 2048 \
     --gradient_checkpointing \

--- a/mdx/train_peft_multi_gpu.sh
+++ b/mdx/train_peft_multi_gpu.sh
@@ -18,7 +18,7 @@ accelerate launch --config_file $config_file \
     --gradient_accumulation_steps $gradient_accumulation_steps \
     --learning_rate 1e-4 \
     --warmup_ratio 0.1 \
-    --lr_scheduler cosine \
+    --lr_scheduler_type cosine \
     --bf16 \
     --max_seq_length 2048 \
     --logging_steps 10 \

--- a/mdx/train_peft_multi_node.sh
+++ b/mdx/train_peft_multi_node.sh
@@ -29,7 +29,7 @@ accelerate launch --config_file $config_file \
     --gradient_accumulation_steps $gradient_accumulation_steps \
     --learning_rate 1e-4 \
     --warmup_ratio 0.1 \
-    --lr_scheduler cosine \
+    --lr_scheduler_type cosine \
     --bf16 \
     --max_seq_length 2048 \
     --logging_steps 10 \

--- a/mdx/train_peft_single_gpu.sh
+++ b/mdx/train_peft_single_gpu.sh
@@ -16,7 +16,7 @@ python train.py \
     --gradient_accumulation_steps $gradient_accumulation_steps \
     --learning_rate 1e-4 \
     --warmup_ratio 0.1 \
-    --lr_scheduler cosine \
+    --lr_scheduler_type cosine \
     --bf16 \
     --max_seq_length 2048 \
     --logging_steps 10 \

--- a/mdx/train_peft_single_gpu_gradient_checkpointing.sh
+++ b/mdx/train_peft_single_gpu_gradient_checkpointing.sh
@@ -16,7 +16,7 @@ python train.py \
     --gradient_accumulation_steps $gradient_accumulation_steps \
     --learning_rate 1e-4 \
     --warmup_ratio 0.1 \
-    --lr_scheduler cosine \
+    --lr_scheduler_type cosine \
     --bf16 \
     --max_seq_length 2048 \
     --gradient_checkpointing \


### PR DESCRIPTION
The formal argument name for `lr_scheduler` is `lr_scheduler_type` in [TrainingArguments](https://github.com/huggingface/transformers/blob/v4.34.0/src/transformers/training_args.py#L239).
Since transformers v4.36.0, Hugging Face added an argument field `lr_scheduler_kwargs` to [TrainingArguments](https://github.com/huggingface/transformers/blob/v4.36.0/src/transformers/training_args.py#L239), which is causing `ambiguous option` error. 
```
train.py: error: ambiguous option: --lr_scheduler could match --lr_scheduler_type, --lr_scheduler_kwargs
```
@hkiyomaru @Taka008 