### PR TITLE
add use_flash_attention_2 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install the necessary packages using `pip`:
 pip install -r requirements.txt
 ```
 
-To enable `use_flash_attention_2` option:
+To turn on `use_flash_attention_2` option:
 ```bash
 pip install flash-attn --no-build-isolation
 ```

--- a/README.md
+++ b/README.md
@@ -205,3 +205,27 @@ accelerate launch --config_file configs/accelerate_config_zero1.yaml \
     --model_name_or_path llm-jp/llm-jp-13b-v1.0 \
     --output_dir results/llm-jp-13b-instruct-lora-jaster-dolly-oasst-v1.0
 ```
+
+### Using flash-attn
+
+The `use_flash_attention_2` option in transformers v4.36 only supports for the models based on Llama and Falcon.
+
+#### For the 7B model (single node; single A100 40GB GPU)
+
+```bash
+CUDA_VISIBLE_DEVICES=0 python train.py \
+    --num_train_epochs 5 \
+    --per_device_train_batch_size 4 \
+    --gradient_accumulation_steps 16 \
+    --learning_rate 1e-4 \
+    --warmup_ratio 0.1 \
+    --lr_scheduler_type cosine \
+    --bf16 \
+    --max_seq_length 2048 \
+    --gradient_checkpointing \
+    --data_files jamp.json janli.json jcommonsenseqa.json jemhopqa.json jnli.json jsem.json jsick.json jsquad.json jsts.json niilc.json dolly_deepl.json oasst_deepl.json \
+    --use_flash_attention_2 True \
+    --use_peft \
+    --model_name_or_path llm-jp/llm-jp-7b \
+    --output_dir results/llm-jp-7b-instruct-lora-jaster-dolly-oasst-v1.0
+```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Install the necessary packages using `pip`:
 pip install -r requirements.txt
 ```
 
+To enable `use_flash_attention_2` option:
+```bash
+pip install flash-attn --no-build-isolation
+```
+
 ## Dataset Preparation
 
 A sample dataset is provided in `data/`. A training example is structured as follows:

--- a/mdx/README.md
+++ b/mdx/README.md
@@ -102,3 +102,29 @@ For LoRA SFT, the default learning-rate is `2e-5` and num epochs is `5`.
     - `$ mdx/train_peft_multi_gpu.sh configs/accelerate_config_zero1.yaml llm-jp/llm-jp-1.3b-v1.0 llm-jp/llm-jp-1.3b-v1.0 ./dataset mdx/dataset_jaster.sh 5 results/llm-jp-1.3b-instruct-lora-jaster-v1.0 8 4`
   - 13B model on A100 40GB 1node_8gpu with `accelerate_config_zero1.yaml`
     - `$ mdx/train_peft_multi_gpu.sh configs/accelerate_config_zero1.yaml llm-jp/llm-jp-13b-v1.0 llm-jp/llm-jp-13b-v1.0 ./dataset mdx/dataset_jaster.sh 5 results/llm-jp-13b-instruct-lora-jaster-v1.0 1 8`
+
+### Using flash-attn
+
+The `use_flash_attention_2` option in transformers v4.36 only supports for the models based on Llama and Falcon.
+
+Enabling `use_flash_attention_2` option can reduce GPU memory usage, which allows you to increase `per_device_train_batch_size` and thus increases training throughput.
+
+#### Single-GPU Training
+(`gradient_checkpointing` is not compatible with `--peft_target_model llama-all`)
+- script:
+  - 7B: `mdx/train_peft_single_gpu.sh`
+- positional args:
+  - model_name_or_path
+  - tokenizer_name_or_path
+  - dataset_path
+  - dataset_sh
+  - num_train_epochs
+  - output_dir
+  - per_device_train_batch_size
+  - gradient_accumulation_steps
+- additional args:
+  - peft_target_model
+  - use_flash_attention_2
+- examples:
+  - 7B model on single A100 40GB
+    - `$ CUDA_VISIBLE_DEVICES=0 mdx/train_peft_single_gpu.sh /model/7B_HF/llm-jp-7b/ /model/7B_HF/llm-jp-7b/ dataset/ mdx/dataset_jaster.sh 5 results/llm-jp-7b-jaster-lora-all 4 16 --peft_target_model llama-all --use_flash_attention_2 True`

--- a/train.py
+++ b/train.py
@@ -30,7 +30,7 @@ class SFTTrainingArguments:
     max_seq_length: int = 2048
     load_in_8bit: bool = False
     load_in_4bit: bool = False
-    use_flash_attention_2 = False
+    use_flash_attention_2: bool = False
     use_peft: bool = False
     peft_target_model: Optional[str] = "llm-jp"
     peft_target_modules: Optional[list[str]] = None

--- a/train.py
+++ b/train.py
@@ -30,6 +30,7 @@ class SFTTrainingArguments:
     max_seq_length: int = 2048
     load_in_8bit: bool = False
     load_in_4bit: bool = False
+    use_flash_attention_2 = False
     use_peft: bool = False
     peft_target_model: Optional[str] = "llm-jp"
     peft_target_modules: Optional[list[str]] = None
@@ -72,9 +73,9 @@ class SFTTrainingArguments:
 
     def from_pretrained_kwargs(self, training_args):
         if self.load_in_8bit:
-            return {"load_in_8bit": True}
+            kwargs = {"load_in_8bit": True}
         elif self.load_in_4bit:
-            return {
+            kwargs = {
                 "quantization_config": BitsAndBytesConfig(
                     load_in_4bit=True,
                     bnb_4bit_use_double_quant=True,
@@ -83,9 +84,11 @@ class SFTTrainingArguments:
                 )
             }
         elif training_args.bf16:
-            return {"torch_dtype": torch.bfloat16}
+            kwargs = {"torch_dtype": torch.bfloat16}
         else:
-            return {"torch_dtype": torch.float16}
+            kwargs = {"torch_dtype": torch.float16}
+        kwargs["use_flash_attention_2"] = self.use_flash_attention_2
+        return kwargs
 
 
 def load_datasets(data_files):


### PR DESCRIPTION
`use_flash_attention_2` increases the training throughput by 1.8 times for the models based on Llama and Falcon. @hkiyomaru @Taka008 