### PR TITLE
Fix peft target modules for Llama architecture

### DIFF
--- a/configs/accelerate_config_zero3.16node.yaml
+++ b/configs/accelerate_config_zero3.16node.yaml
@@ -19,4 +19,3 @@ deepspeed_config:
   offload_param_device: null
   zero3_init_flag: true
   zero3_save_16bit_model: true
-  

--- a/train.py
+++ b/train.py
@@ -51,6 +51,9 @@ class SFTTrainingArguments:
                     "k_proj",
                     "v_proj",
                     "o_proj",
+                    "gate_proj",
+                    "up_proj",
+                    "down_proj",
                 ]
             elif self.peft_target_model == "llama-all":
                 # https://note.com/kan_hatakeyama/n/ncd09c52d26c7
@@ -129,7 +132,9 @@ def main() -> None:
     instruction_ids = tokenizer.encode("\n\n### 指示:\n", add_special_tokens=False)[1:]
     response_ids = tokenizer.encode("\n\n### 応答:\n", add_special_tokens=False)[1:]
     collator = DataCollatorForCompletionOnlyLM(
-        instruction_template=instruction_ids, response_template=response_ids, tokenizer=tokenizer
+        instruction_template=instruction_ids,
+        response_template=response_ids,
+        tokenizer=tokenizer,
     )
 
     logger.info(f"Loading model from {sft_training_args.model_name_or_path}")


### PR DESCRIPTION
現状のコードでは GPT2アーキテクチャの方では mlp 層内の線形層まで LoRA の対象になっているが，Llama の方では対象になっていなかったので修正

（参考）
GPT-2（llm-jp モデル ver1）
```
GPT2LMHeadModel(
  (transformer): GPT2Model(
    (wte): Embedding(50688, 5120)
    (wpe): Embedding(2048, 5120)
    (drop): Dropout(p=0.1, inplace=False)
    (h): ModuleList(
      (0-39): 40 x GPT2Block(
        (ln_1): LayerNorm((5120,), eps=1e-05, elementwise_affine=True)
        (attn): GPT2Attention(
          (c_attn): Conv1D()
          (c_proj): Conv1D()
          (attn_dropout): Dropout(p=0.1, inplace=False)
          (resid_dropout): Dropout(p=0.1, inplace=False)
        )
        (ln_2): LayerNorm((5120,), eps=1e-05, elementwise_affine=True)
        (mlp): GPT2MLP(
          (c_fc): Conv1D()
          (c_proj): Conv1D()
          (act): GELUActivation()
          (dropout): Dropout(p=0.1, inplace=False)
        )
      )
    )
    (ln_f): LayerNorm((5120,), eps=1e-05, elementwise_affine=True)
  )
  (lm_head): Linear(in_features=5120, out_features=50688, bias=False)
)
```

Llama（llm-jp モデル ver2）
```
LlamaForCausalLM(
  (model): LlamaModel(
    (embed_tokens): Embedding(97024, 5120, padding_idx=0)
    (layers): ModuleList(
      (0-39): 40 x LlamaDecoderLayer(
        (self_attn): LlamaSdpaAttention(
          (q_proj): Linear(in_features=5120, out_features=5120, bias=False)
          (k_proj): Linear(in_features=5120, out_features=5120, bias=False)
          (v_proj): Linear(in_features=5120, out_features=5120, bias=False)
          (o_proj): Linear(in_features=5120, out_features=5120, bias=False)
          (rotary_emb): LlamaRotaryEmbedding()
        )
        (mlp): LlamaMLP(
          (gate_proj): Linear(in_features=5120, out_features=13824, bias=False)
          (up_proj): Linear(in_features=5120, out_features=13824, bias=False)
          (down_proj): Linear(in_features=13824, out_features=5120, bias=False)
          (act_fn): SiLU()
        )
        (input_layernorm): LlamaRMSNorm()
        (post_attention_layernorm): LlamaRMSNorm()
      )
    )
    (norm): LlamaRMSNorm()
  )
  (lm_head): Linear(in_features=5120, out_features=97024, bias=False)
)
```