### PR TITLE
Install wheel before flash-attn

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ pip install -r requirements.txt
 
 To turn on `use_flash_attention_2` option:
 ```bash
+pip install wheel
 pip install flash-attn --no-build-isolation
 ```
 


### PR DESCRIPTION
We need to install wheel before flash-attn.

```
$ pip install flash-attn --no-build-isolation
Collecting flash-attn
  Downloading flash_attn-2.5.5.tar.gz (2.5 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.5/2.5 MB 17.7 MB/s eta 0:00:00
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-xbsgez9z/flash-attn_416ceeeec74f445d90b19302d3f4bca2/setup.py", line 17, in <module>
          from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
      ModuleNotFoundError: No module named 'wheel'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```